### PR TITLE
docs: apply NVIDIA style guide to NGC authentication section

### DIFF
--- a/docs/tutorials/nemo-rl-grpo/setup.md
+++ b/docs/tutorials/nemo-rl-grpo/setup.md
@@ -51,18 +51,18 @@ The NeMo RL container is hosted on NVIDIA GPU Cloud (NGC), which requires authen
 
 1. Go to [NGC API Keys](https://org.ngc.nvidia.com/setup/api-keys)
 2. Click **Generate API Key**
-3. Copy the generated key (you won't be able to see it again)
+3. Copy the generated key now—you cannot view it again.
 
 :::{important}
-Store your API key securely. You'll need it for container authentication.
+Store your API key securely. You will need it for container authentication.
 :::
 
 ### Authenticate with Docker
 
-If you're using Docker as your container runtime:
+If you are using Docker as your container runtime:
 
 ```bash
-# Login to NGC registry
+# Log in to the NGC registry
 docker login nvcr.io
 
 # When prompted:
@@ -74,7 +74,7 @@ docker login nvcr.io
 
 ### Authenticate with enroot
 
-If you're using enroot as your container runtime:
+If you are using enroot as your container runtime:
 
 ```bash
 # Create credentials file


### PR DESCRIPTION
Stacked on top of #632. This PR applies NVIDIA documentation style guide edits to the NGC authentication section that #632 adds to `docs/tutorials/nemo-rl-grpo/setup.md`.

## Style guide edits

- **Remove contractions** (technical docs avoid contractions per the NVIDIA style guide):
  - "you won't be able to see it again" → "you cannot view it again"
  - "You'll need it" → "You will need it"
  - "If you're using Docker" → "If you are using Docker"
  - "If you're using enroot" → "If you are using enroot"
- **Fix verb form**: `# Login to NGC registry` → `# Log in to the NGC registry` ("log in" is the verb; "login" is a noun)
- **Add missing trailing newline** at end of file

These are surface-level style corrections only — no changes to commands, structure, or instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
